### PR TITLE
Add HTTP406

### DIFF
--- a/httpexceptor/__init__.py
+++ b/httpexceptor/__init__.py
@@ -180,6 +180,12 @@ class HTTP404(HTTPException):
     status = __doc__
 
 
+class HTTP406(HTTPException):
+    """406 Not Acceptable"""
+
+    status = __doc__
+
+
 class HTTP409(HTTPException):
     """409 Conflict"""
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -136,6 +136,15 @@ def test_404():
     assert body == '404 Not Found: error message'
 
 
+def test_406():
+    status, headers, body = mock_response(406)
+
+    assert status == _status(406)
+    assert len(headers) == 1
+    assert headers['Content-Type'] == 'text/plain; charset=UTF-8'
+    assert body == '406 Not Acceptable: error message'
+
+
 def test_409():
     status, headers, body = mock_response(409)
 


### PR DESCRIPTION
It wasn't there, and it would be useful to have. 406 doesn't make
any demands on headers, so the implementation is straightforward.
